### PR TITLE
RMQSource refactor

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeliveryParser.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeliveryParser.java
@@ -1,0 +1,37 @@
+package org.apache.flink.streaming.connectors.rabbitmq;
+
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Envelope;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * Interface for the set of methods required to parse an RMQ delivery to an output.
+ * @param <T> The output type of the {@link RMQSource}
+ */
+public interface RMQDeliveryParser<T> extends Serializable, ResultTypeQueryable<T> {
+	/**
+	 * This method takes all the RabbitMQ delivery information supplied by the client and returns an output matching
+	 * the {@link RMQSource} output type. For more information about what the {@link Envelope},
+	 * {@link AMQP.BasicProperties} please refer to the RabbitMQ java client library.
+	 * @param envelope
+	 * @param properties
+	 * @param body
+	 * @return an output T matching the output of the RMQSource
+	 * @throws IOException
+	 */
+	public T parse(Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException;
+
+	/**
+	 * A method that extracts a unique correlation id from the RabbitMQ delivery and metadata. This ID is used for
+	 * deduplicating the messages in the RMQSource.
+	 * @param envelope
+	 * @param properties
+	 * @param body
+	 * @return
+	 */
+	public String getCorrelationID(Envelope envelope, AMQP.BasicProperties properties, byte[] body);
+}

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeliveryParser.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeliveryParser.java
@@ -9,14 +9,13 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /**
- * Interface for the set of methods required to parse an RMQ delivery to an output.
+ * Interface for the set of methods required to parse an RMQ delivery.
  * @param <T> The output type of the {@link RMQSource}
  */
 public interface RMQDeliveryParser<T> extends Serializable, ResultTypeQueryable<T> {
 	/**
 	 * This method takes all the RabbitMQ delivery information supplied by the client and returns an output matching
-	 * the {@link RMQSource} output type. For more information about what the {@link Envelope},
-	 * {@link AMQP.BasicProperties} please refer to the RabbitMQ java client library.
+	 * the {@link RMQSource}.
 	 * @param envelope
 	 * @param properties
 	 * @param body
@@ -26,7 +25,7 @@ public interface RMQDeliveryParser<T> extends Serializable, ResultTypeQueryable<
 	public T parse(Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException;
 
 	/**
-	 * A method that extracts a unique correlation id from the RabbitMQ delivery and metadata. This ID is used for
+	 * A method that extracts a unique correlation id from the RabbitMQ delivery information. This ID is used for
 	 * deduplicating the messages in the RMQSource.
 	 * @param envelope
 	 * @param properties

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -331,6 +331,6 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 
 	@Override
 	public TypeInformation<OUT> getProducedType() {
-		return deliveryParser.getProducedType();
+		return deliveryParser == null ? schema.getProducedType() : deliveryParser.getProducedType();
 	}
 }

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -100,7 +100,8 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 	 * @param deserializationSchema A {@link DeserializationSchema} for turning the bytes received
 	 *               				into Java objects.
 	 */
-	public RMQSource(RMQConnectionConfig rmqConnectionConfig, String queueName, DeserializationSchema<OUT> deserializationSchema) {
+	public RMQSource(RMQConnectionConfig rmqConnectionConfig, String queueName,
+					DeserializationSchema<OUT> deserializationSchema) {
 		this(rmqConnectionConfig, queueName, false, deserializationSchema);
 	}
 
@@ -117,7 +118,8 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 	 * @param deserializationSchema A {@link DeserializationSchema} for turning the bytes received
 	 *                              into Java objects.
 	 */
-	public RMQSource(RMQConnectionConfig rmqConnectionConfig, String queueName, boolean usesCorrelationId, DeserializationSchema<OUT> deserializationSchema) {
+	public RMQSource(RMQConnectionConfig rmqConnectionConfig,
+					String queueName, boolean usesCorrelationId, DeserializationSchema<OUT> deserializationSchema) {
 		super(String.class);
 		this.rmqConnectionConfig = rmqConnectionConfig;
 		this.queueName = queueName;
@@ -132,7 +134,7 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 	 * <p>For exactly-once, please use the constructor
 	 * {@link RMQSource#RMQSource(RMQConnectionConfig, String, boolean, RMQDeliveryParser)}.
 	 *
-	 * It also uses the provided {@link RMQDeliveryParser} to parse both the correlationID and the message.
+	 * <p>It also uses the provided {@link RMQDeliveryParser} to parse both the correlationID and the message.
 	 * @param rmqConnectionConfig The RabbiMQ connection configuration {@link RMQConnectionConfig}.
 	 * @param queueName  The queue to receive messages from.
 	 * @param deliveryParser A {@link RMQDeliveryParser} for parsing the RMQDelivery.
@@ -148,7 +150,7 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 	 * undefined. If in doubt, set usesCorrelationId to false. When correlation ids are not
 	 * used, this source has at-least-once processing semantics when checkpointing is enabled.
 	 *
-	 * It also uses the provided {@link RMQDeliveryParser} to parse both the correlationID and the message.
+	 * <p>It also uses the provided {@link RMQDeliveryParser} to parse both the correlationID and the message.
 	 * @param rmqConnectionConfig The RabbiMQ connection configuration {@link RMQConnectionConfig}.
 	 * @param queueName The queue to receive messages from.
 	 * @param usesCorrelationId Whether the messages received are supplied with a <b>unique</b>
@@ -231,10 +233,10 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 	/**
 	 * Parse and returns the body of the an AMQP message.
 	 *
-	 * If any of the constructors with the {@link DeserializationSchema} class was used to construct the source
+	 * <p>If any of the constructors with the {@link DeserializationSchema} class was used to construct the source
 	 * it uses the {@link DeserializationSchema#deserialize(byte[])} to parse the body of the AMQP message.
 	 *
-	 * If any of the constructors with the {@link RMQDeliveryParser } class was used to construct the source it uses the
+	 * <p>If any of the constructors with the {@link RMQDeliveryParser } class was used to construct the source it uses the
 	 * {@link RMQDeliveryParser#parse(Envelope, AMQP.BasicProperties, byte[])} method of that provided instance.
 	 *
 	 * @param envelope
@@ -254,10 +256,10 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 	/**
 	 * Extracts and returns the correlationID.
 	 *
-	 * If any of the constructors with the {@link DeserializationSchema} class was used to construct the source
+	 * <p>If any of the constructors with the {@link DeserializationSchema} class was used to construct the source
 	 * it uses the {@link AMQP.BasicProperties#getCorrelationId()} to retrieve the correlationID.
 	 *
-	 * If any of the constructors with the {@link RMQDeliveryParser } class was used to construct the source it uses the
+	 * <p>If any of the constructors with the {@link RMQDeliveryParser } class was used to construct the source it uses the
 	 * {@link RMQDeliveryParser#getCorrelationID(Envelope, AMQP.BasicProperties, byte[])} to retrieve the correlationID.
 	 *
 	 * @param envelope


### PR DESCRIPTION
* Instead of passing a DeserializationSchema to the constructor you pass
  an instance of RMQDeliveryParser.
* RMQDeliveryParser instances have access to the Envelope,
  AMQP.BasicProperties and body of the message to be able to extract
  whatever information they need out of it.
* RMQDeliveryParser is able to also extract the message corrolation ID
  from the envelope, AMQP.BasicProperties and or the body of the
  message giving you the flexibility to rely on another field other than
  the AMQP.BasicProperties.getProperties().getCorrolationID()